### PR TITLE
change requirement to jsonobject-couchdbkit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 restkit
-couchdbkit
+jsonobject-couchdbkit
 django-debug-toolbar


### PR DESCRIPTION
This was causing couchdbkit to get installed anytime you updated the dev requirements.
Think I should just remove the requirement altogether?
